### PR TITLE
Support pythia as LLM component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ ckpts*
 robin-[0-9]*_loss.png
 scripts/robin_v2/pretrain_multinodes_[0-9]*.sh
 scripts/robin_v2/finetune_lora_multinodes_[0-9]*.sh
+
+playground-original/

--- a/log.out
+++ b/log.out
@@ -1,0 +1,187 @@
+[2024-01-07 17:45:05,224] [INFO] [real_accelerator.py:110:get_accelerator] Setting ds_accelerator to cuda (auto detect)
+[2024-01-07 17:45:07,930] [WARNING] [runner.py:196:fetch_hostfile] Unable to find hostfile, will proceed with training with local resources only.
+Detected CUDA_VISIBLE_DEVICES=0,1: setting --include=localhost:0,1
+[2024-01-07 17:45:07,930] [INFO] [runner.py:555:main] cmd = /home/lfsm/miniconda3/bin/python -u -m deepspeed.launcher.launch --world_info=eyJsb2NhbGhvc3QiOiBbMCwgMV19 --master_addr=127.0.0.1 --master_port=29500 --enable_each_rank_log=None /home/lfsm/code/Robin//robin/train/train_mem.py --deepspeed ./scripts/zero2.json --model_name_or_path EleutherAI/pythia-410m --version plain --data_path /home/lfsm/code/Robin/playground-original/llava_pretrain/blip_laion_cc_sbu_558k.json --image_folder /home/lfsm/code/Robin/playground-original/llava_pretrain/images --vision_tower openai/clip-vit-large-patch14-336 --finetune_ve False --mm_projector_type mlp2x_gelu --tune_mm_mlp_adapter True --mm_vision_select_layer -2 --mm_use_im_start_end False --mm_use_im_patch_token False --fp16 True --output_dir /home/lfsm/code/Robin/robin/checkpoints/pretrain --num_train_epochs 1 --per_device_train_batch_size 32 --per_device_eval_batch_size 4 --gradient_accumulation_steps 1 --evaluation_strategy no --save_strategy steps --save_steps 100 --save_total_limit 1 --learning_rate 1e-3 --weight_decay 0. --warmup_ratio 0.03 --lr_scheduler_type cosine --logging_steps 1 --tf32 False --model_max_length 2048 --gradient_checkpointing False --dataloader_num_workers 4 --lazy_preprocess True
+[2024-01-07 17:45:09,209] [INFO] [real_accelerator.py:110:get_accelerator] Setting ds_accelerator to cuda (auto detect)
+[2024-01-07 17:45:11,718] [INFO] [launch.py:145:main] WORLD INFO DICT: {'localhost': [0, 1]}
+[2024-01-07 17:45:11,718] [INFO] [launch.py:151:main] nnodes=1, num_local_procs=2, node_rank=0
+[2024-01-07 17:45:11,718] [INFO] [launch.py:162:main] global_rank_mapping=defaultdict(<class 'list'>, {'localhost': [0, 1]})
+[2024-01-07 17:45:11,718] [INFO] [launch.py:163:main] dist_world_size=2
+[2024-01-07 17:45:11,718] [INFO] [launch.py:165:main] Setting CUDA_VISIBLE_DEVICES=0,1
+[2024-01-07 17:45:14,859] [INFO] [real_accelerator.py:110:get_accelerator] Setting ds_accelerator to cuda (auto detect)
+[2024-01-07 17:45:14,863] [INFO] [real_accelerator.py:110:get_accelerator] Setting ds_accelerator to cuda (auto detect)
+[2024-01-07 17:45:16,541] [WARNING] [comm.py:152:init_deepspeed_backend] NCCL backend in DeepSpeed not yet implemented
+[2024-01-07 17:45:16,541] [WARNING] [comm.py:152:init_deepspeed_backend] NCCL backend in DeepSpeed not yet implemented
+[2024-01-07 17:45:16,541] [INFO] [comm.py:594:init_distributed] cdb=None
+[2024-01-07 17:45:16,541] [INFO] [comm.py:594:init_distributed] cdb=None
+[2024-01-07 17:45:16,541] [INFO] [comm.py:625:init_distributed] Initializing TorchBackend in DeepSpeed with backend nccl
+ModelArguments(model_name_or_path='EleutherAI/pythia-410m', version='plain', freeze_backbone=False, tune_mm_mlp_adapter=True, vision_tower='openai/clip-vit-large-patch14-336', mm_vision_select_layer=-2, pretrain_mm_mlp_adapter=None, mm_projector_type='mlp2x_gelu', mm_use_im_start_end=False, mm_use_im_patch_token=False, mm_vision_select_feature='patch')
+ModelArguments(model_name_or_path='EleutherAI/pythia-410m', version='plain', freeze_backbone=False, tune_mm_mlp_adapter=True, vision_tower='openai/clip-vit-large-patch14-336', mm_vision_select_layer=-2, pretrain_mm_mlp_adapter=None, mm_projector_type='mlp2x_gelu', mm_use_im_start_end=False, mm_use_im_patch_token=False, mm_vision_select_feature='patch')
+Formatting inputs...Skip in lazy mode
+LlavaGPTNeoXForCausalLM(
+  (gpt_neox): LlavaGPTNeoXModel(
+    (embed_in): Embedding(50304, 1024)
+    (emb_dropout): Dropout(p=0.0, inplace=False)
+    (layers): ModuleList(
+      (0-23): 24 x GPTNeoXLayer(
+        (input_layernorm): LayerNorm((1024,), eps=1e-05, elementwise_affine=True)
+        (post_attention_layernorm): LayerNorm((1024,), eps=1e-05, elementwise_affine=True)
+        (post_attention_dropout): Dropout(p=0.0, inplace=False)
+        (post_mlp_dropout): Dropout(p=0.0, inplace=False)
+        (attention): GPTNeoXAttention(
+          (rotary_emb): GPTNeoXRotaryEmbedding()
+          (query_key_value): Linear(in_features=1024, out_features=3072, bias=True)
+          (dense): Linear(in_features=1024, out_features=1024, bias=True)
+          (attention_dropout): Dropout(p=0.0, inplace=False)
+        )
+        (mlp): GPTNeoXMLP(
+          (dense_h_to_4h): Linear(in_features=1024, out_features=4096, bias=True)
+          (dense_4h_to_h): Linear(in_features=4096, out_features=1024, bias=True)
+          (act): GELUActivation()
+        )
+      )
+    )
+    (final_layer_norm): LayerNorm((1024,), eps=1e-05, elementwise_affine=True)
+    (vision_tower): CLIPVisionTower(
+      (vision_tower): CLIPVisionModel(
+        (vision_model): CLIPVisionTransformer(
+          (embeddings): CLIPVisionEmbeddings(
+            (patch_embedding): Conv2d(3, 1024, kernel_size=(14, 14), stride=(14, 14), bias=False)
+            (position_embedding): Embedding(577, 1024)
+          )
+          (pre_layrnorm): LayerNorm((1024,), eps=1e-05, elementwise_affine=True)
+          (encoder): CLIPEncoder(
+            (layers): ModuleList(
+              (0-23): 24 x CLIPEncoderLayer(
+                (self_attn): CLIPAttention(
+                  (k_proj): Linear(in_features=1024, out_features=1024, bias=True)
+                  (v_proj): Linear(in_features=1024, out_features=1024, bias=True)
+                  (q_proj): Linear(in_features=1024, out_features=1024, bias=True)
+                  (out_proj): Linear(in_features=1024, out_features=1024, bias=True)
+                )
+                (layer_norm1): LayerNorm((1024,), eps=1e-05, elementwise_affine=True)
+                (mlp): CLIPMLP(
+                  (activation_fn): QuickGELUActivation()
+                  (fc1): Linear(in_features=1024, out_features=4096, bias=True)
+                  (fc2): Linear(in_features=4096, out_features=1024, bias=True)
+                )
+                (layer_norm2): LayerNorm((1024,), eps=1e-05, elementwise_affine=True)
+              )
+            )
+          )
+          (post_layernorm): LayerNorm((1024,), eps=1e-05, elementwise_affine=True)
+        )
+      )
+    )
+    (mm_projector): Sequential(
+      (0): Linear(in_features=1024, out_features=1024, bias=True)
+      (1): GELU(approximate='none')
+      (2): Linear(in_features=1024, out_features=1024, bias=True)
+    )
+  )
+  (embed_out): Linear(in_features=1024, out_features=50304, bias=False)
+)
+Rank: 1 partition count [2, 2] and sizes[(1048576, False), (1024, False)] 
+Rank: 0 partition count [2, 2] and sizes[(1048576, False), (1024, False)] 
+{'loss': 7.5859, 'learning_rate': 0.0, 'epoch': 0.0}
+{'loss': 7.4512, 'learning_rate': 0.0, 'epoch': 0.0}
+{'loss': 7.4219, 'learning_rate': 0.0, 'epoch': 0.0}
+{'loss': 7.4668, 'learning_rate': 3.816793893129771e-06, 'epoch': 0.0}
+{'loss': 7.7051, 'learning_rate': 7.633587786259541e-06, 'epoch': 0.0}
+{'loss': 7.6035, 'learning_rate': 1.1450381679389314e-05, 'epoch': 0.0}
+{'loss': 7.252, 'learning_rate': 1.1450381679389314e-05, 'epoch': 0.0}
+{'loss': 7.4199, 'learning_rate': 1.5267175572519083e-05, 'epoch': 0.0}
+{'loss': 7.2754, 'learning_rate': 1.9083969465648855e-05, 'epoch': 0.0}
+{'loss': 7.4746, 'learning_rate': 2.2900763358778628e-05, 'epoch': 0.0}
+{'loss': 7.043, 'learning_rate': 2.6717557251908397e-05, 'epoch': 0.0}
+{'loss': 7.0898, 'learning_rate': 3.0534351145038166e-05, 'epoch': 0.0}
+{'loss': 7.0801, 'learning_rate': 3.435114503816794e-05, 'epoch': 0.0}
+{'loss': 6.4941, 'learning_rate': 3.816793893129771e-05, 'epoch': 0.0}
+{'loss': 6.6426, 'learning_rate': 4.198473282442748e-05, 'epoch': 0.0}
+{'loss': 6.543, 'learning_rate': 4.5801526717557256e-05, 'epoch': 0.0}
+{'loss': 6.5801, 'learning_rate': 4.9618320610687025e-05, 'epoch': 0.0}
+{'loss': 6.7246, 'learning_rate': 5.3435114503816794e-05, 'epoch': 0.0}
+{'loss': 6.4609, 'learning_rate': 5.725190839694656e-05, 'epoch': 0.0}
+{'loss': 6.3926, 'learning_rate': 6.106870229007633e-05, 'epoch': 0.0}
+{'loss': 6.3008, 'learning_rate': 6.488549618320611e-05, 'epoch': 0.0}
+{'loss': 6.3223, 'learning_rate': 6.870229007633588e-05, 'epoch': 0.0}
+{'loss': 6.2383, 'learning_rate': 7.251908396946565e-05, 'epoch': 0.0}
+{'loss': 5.8535, 'learning_rate': 7.633587786259542e-05, 'epoch': 0.0}
+{'loss': 5.9766, 'learning_rate': 8.015267175572518e-05, 'epoch': 0.0}
+{'loss': 5.9805, 'learning_rate': 8.396946564885496e-05, 'epoch': 0.0}
+{'loss': 6.1367, 'learning_rate': 8.778625954198472e-05, 'epoch': 0.0}
+{'loss': 6.0039, 'learning_rate': 9.160305343511451e-05, 'epoch': 0.0}
+{'loss': 5.8262, 'learning_rate': 9.541984732824429e-05, 'epoch': 0.0}
+{'loss': 5.8359, 'learning_rate': 9.923664122137405e-05, 'epoch': 0.0}
+{'loss': 5.8984, 'learning_rate': 0.00010305343511450383, 'epoch': 0.0}
+{'loss': 5.9121, 'learning_rate': 0.00010687022900763359, 'epoch': 0.0}
+{'loss': 5.9883, 'learning_rate': 0.00011068702290076336, 'epoch': 0.0}
+{'loss': 5.5684, 'learning_rate': 0.00011450381679389313, 'epoch': 0.0}
+{'loss': 5.6367, 'learning_rate': 0.0001183206106870229, 'epoch': 0.0}
+{'loss': 5.8906, 'learning_rate': 0.00012213740458015266, 'epoch': 0.0}
+{'loss': 5.541, 'learning_rate': 0.00012595419847328244, 'epoch': 0.0}
+{'loss': 5.7383, 'learning_rate': 0.00012977099236641222, 'epoch': 0.0}
+{'loss': 5.4785, 'learning_rate': 0.000133587786259542, 'epoch': 0.0}
+{'loss': 5.9375, 'learning_rate': 0.00013740458015267177, 'epoch': 0.0}
+{'loss': 5.4922, 'learning_rate': 0.00014122137404580154, 'epoch': 0.0}
+{'loss': 5.5957, 'learning_rate': 0.0001450381679389313, 'epoch': 0.0}
+{'loss': 5.375, 'learning_rate': 0.00014885496183206107, 'epoch': 0.0}
+{'loss': 5.625, 'learning_rate': 0.00015267175572519084, 'epoch': 0.01}
+{'loss': 5.4316, 'learning_rate': 0.00015648854961832062, 'epoch': 0.01}
+{'loss': 5.3613, 'learning_rate': 0.00016030534351145037, 'epoch': 0.01}
+{'loss': 5.3008, 'learning_rate': 0.00016412213740458014, 'epoch': 0.01}
+{'loss': 5.2715, 'learning_rate': 0.00016793893129770992, 'epoch': 0.01}
+{'loss': 5.3379, 'learning_rate': 0.0001717557251908397, 'epoch': 0.01}
+{'loss': 5.5723, 'learning_rate': 0.00017557251908396944, 'epoch': 0.01}
+{'loss': 5.3398, 'learning_rate': 0.00017938931297709925, 'epoch': 0.01}
+{'loss': 5.3027, 'learning_rate': 0.00018320610687022902, 'epoch': 0.01}
+{'loss': 5.3164, 'learning_rate': 0.0001870229007633588, 'epoch': 0.01}
+{'loss': 5.3145, 'learning_rate': 0.00019083969465648857, 'epoch': 0.01}
+{'loss': 5.1719, 'learning_rate': 0.00019465648854961832, 'epoch': 0.01}
+{'loss': 5.3398, 'learning_rate': 0.0001984732824427481, 'epoch': 0.01}
+{'loss': 5.3438, 'learning_rate': 0.00020229007633587788, 'epoch': 0.01}
+{'loss': 5.1465, 'learning_rate': 0.00020610687022900765, 'epoch': 0.01}
+{'loss': 5.3574, 'learning_rate': 0.0002099236641221374, 'epoch': 0.01}
+{'loss': 5.1562, 'learning_rate': 0.00021374045801526718, 'epoch': 0.01}
+{'loss': 4.9629, 'learning_rate': 0.00021755725190839695, 'epoch': 0.01}
+{'loss': 5.0723, 'learning_rate': 0.00022137404580152673, 'epoch': 0.01}
+{'loss': 4.9688, 'learning_rate': 0.00022519083969465648, 'epoch': 0.01}
+{'loss': 5.0742, 'learning_rate': 0.00022900763358778625, 'epoch': 0.01}
+{'loss': 5.1289, 'learning_rate': 0.00023282442748091603, 'epoch': 0.01}
+{'loss': 5.3867, 'learning_rate': 0.0002366412213740458, 'epoch': 0.01}
+{'loss': 5.1641, 'learning_rate': 0.00024045801526717558, 'epoch': 0.01}
+{'loss': 5.1016, 'learning_rate': 0.00024427480916030533, 'epoch': 0.01}
+{'loss': 5.123, 'learning_rate': 0.00024809160305343513, 'epoch': 0.01}
+{'loss': 4.7285, 'learning_rate': 0.0002519083969465649, 'epoch': 0.01}
+{'loss': 5.1562, 'learning_rate': 0.00025572519083969463, 'epoch': 0.01}
+{'loss': 5.2285, 'learning_rate': 0.00025954198473282443, 'epoch': 0.01}
+{'loss': 4.9883, 'learning_rate': 0.0002633587786259542, 'epoch': 0.01}
+{'loss': 4.9883, 'learning_rate': 0.000267175572519084, 'epoch': 0.01}
+{'loss': 5.0488, 'learning_rate': 0.00027099236641221373, 'epoch': 0.01}
+{'loss': 4.8301, 'learning_rate': 0.00027480916030534353, 'epoch': 0.01}
+{'loss': 5.1191, 'learning_rate': 0.0002786259541984733, 'epoch': 0.01}
+{'loss': 4.834, 'learning_rate': 0.0002824427480916031, 'epoch': 0.01}
+{'loss': 4.7598, 'learning_rate': 0.0002862595419847328, 'epoch': 0.01}
+{'loss': 4.8281, 'learning_rate': 0.0002900763358778626, 'epoch': 0.01}
+{'loss': 5.0449, 'learning_rate': 0.0002938931297709924, 'epoch': 0.01}
+{'loss': 4.9062, 'learning_rate': 0.00029770992366412214, 'epoch': 0.01}
+{'loss': 4.9531, 'learning_rate': 0.00030152671755725194, 'epoch': 0.01}
+{'loss': 4.8477, 'learning_rate': 0.0003053435114503817, 'epoch': 0.01}
+{'loss': 4.75, 'learning_rate': 0.0003091603053435115, 'epoch': 0.01}
+{'loss': 5.0859, 'learning_rate': 0.00031297709923664124, 'epoch': 0.01}
+{'loss': 4.8926, 'learning_rate': 0.000316793893129771, 'epoch': 0.01}
+{'loss': 4.6113, 'learning_rate': 0.00032061068702290074, 'epoch': 0.01}
+{'loss': 4.8867, 'learning_rate': 0.00032442748091603054, 'epoch': 0.01}
+{'loss': 4.7676, 'learning_rate': 0.0003282442748091603, 'epoch': 0.01}
+{'loss': 4.8086, 'learning_rate': 0.0003320610687022901, 'epoch': 0.01}
+{'loss': 4.5547, 'learning_rate': 0.00033587786259541984, 'epoch': 0.01}
+{'loss': 5.0684, 'learning_rate': 0.00033969465648854964, 'epoch': 0.01}
+{'loss': 4.9688, 'learning_rate': 0.0003435114503816794, 'epoch': 0.01}
+{'loss': 4.7578, 'learning_rate': 0.0003473282442748092, 'epoch': 0.01}
+{'loss': 4.7852, 'learning_rate': 0.0003511450381679389, 'epoch': 0.01}
+{'loss': 4.8984, 'learning_rate': 0.0003549618320610687, 'epoch': 0.01}
+{'loss': 4.6875, 'learning_rate': 0.0003587786259541985, 'epoch': 0.01}
+{'loss': 4.6992, 'learning_rate': 0.00036259541984732824, 'epoch': 0.01}
+[2024-01-07 17:47:33,217] [INFO] [launch.py:315:sigkill_handler] Killing subprocess 3614764
+[2024-01-07 17:47:33,509] [INFO] [launch.py:315:sigkill_handler] Killing subprocess 3614765
+[2024-01-07 17:47:33,815] [INFO] [launch.py:324:sigkill_handler] Main process received SIGINT, exiting

--- a/robin/model/builder.py
+++ b/robin/model/builder.py
@@ -34,7 +34,7 @@ def load_pretrained_model(model_path, model_base, model_name, load_8bit=False, l
     
     if 'mistral' in model_name:
         model = LlavaMistralForCausalLM.from_pretrained(model_base, low_cpu_mem_usage=True, config=lora_cfg_pretrained, **kwargs)
-    elif 'neox' in model_name:
+    elif 'pythia' in model_name:
         model = LlavaGPTNeoXForCausalLM.from_pretrained(model_base, low_cpu_mem_usage=True, config=lora_cfg_pretrained, **kwargs)
     else:
         model = LlavaLlamaForCausalLM.from_pretrained(

--- a/robin/model/language_model/llava_neox.py
+++ b/robin/model/language_model/llava_neox.py
@@ -46,9 +46,9 @@ class LlavaGPTNeoXForCausalLM(GPTNeoXForCausalLM, LlavaMetaForCausalLM):
 
     def __init__(self, config):
         super(GPTNeoXForCausalLM, self).__init__(config)
-        self.gpt_neox = LlavaGPTNeoXModel(config) # mimic the GPTNeoXForCausalLM name strategy
-        
-        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        # mimic the GPTNeoXForCausalLM name strategy
+        self.gpt_neox = LlavaGPTNeoXModel(config) 
+        self.embed_out = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
 
         # Initialize weights and apply final processing
         self.post_init()
@@ -90,7 +90,7 @@ class LlavaGPTNeoXForCausalLM(GPTNeoXForCausalLM, LlavaMetaForCausalLM):
         )
 
         hidden_states = outputs[0]
-        logits = self.lm_head(hidden_states)
+        logits = self.embed_out(hidden_states)
 
         loss = None
         if labels is not None:

--- a/robin/model/language_model/llava_neox.py
+++ b/robin/model/language_model/llava_neox.py
@@ -36,6 +36,9 @@ class LlavaGPTNeoXModel(LlavaMetaModel, GPTNeoXModel):
 
     def __init__(self, config: GPTNeoXConfig):
         super(LlavaGPTNeoXModel, self).__init__(config)
+    
+    def embed_tokens(self, x):
+        return self.embed_in(x)
 
 
 class LlavaGPTNeoXForCausalLM(GPTNeoXForCausalLM, LlavaMetaForCausalLM):
@@ -45,7 +48,6 @@ class LlavaGPTNeoXForCausalLM(GPTNeoXForCausalLM, LlavaMetaForCausalLM):
         # init using the super class of GPTNeoXForCausalLM
         super(GPTNeoXForCausalLM, self).__init__(config)
         self.model = LlavaGPTNeoXModel(config)
-        self.vocab_size = config.vocab_size
         self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
 
         # Initialize weights and apply final processing

--- a/robin/model/language_model/llava_neox.py
+++ b/robin/model/language_model/llava_neox.py
@@ -45,16 +45,16 @@ class LlavaGPTNeoXForCausalLM(GPTNeoXForCausalLM, LlavaMetaForCausalLM):
     config_class = LlavaConfig
 
     def __init__(self, config):
-        # init using the super class of GPTNeoXForCausalLM
         super(GPTNeoXForCausalLM, self).__init__(config)
-        self.model = LlavaGPTNeoXModel(config)
+        self.gpt_neox = LlavaGPTNeoXModel(config) # mimic the GPTNeoXForCausalLM name strategy
+        
         self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
 
         # Initialize weights and apply final processing
         self.post_init()
 
     def get_model(self):
-        return self.model
+        return self.gpt_neox
 
     def forward(
         self,
@@ -78,7 +78,7 @@ class LlavaGPTNeoXForCausalLM(GPTNeoXForCausalLM, LlavaMetaForCausalLM):
         input_ids, attention_mask, past_key_values, inputs_embeds, labels = self.prepare_inputs_labels_for_multimodal(input_ids, attention_mask, past_key_values, labels, images)
 
         # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
-        outputs = self.model(
+        outputs = self.gpt_neox(
             input_ids=input_ids,
             attention_mask=attention_mask,
             past_key_values=past_key_values,

--- a/robin/train/train.py
+++ b/robin/train/train.py
@@ -31,7 +31,7 @@ from torch.utils.data import Dataset
 from robin.train.llava_trainer import LLaVATrainer
 
 from robin import conversation as conversation_lib
-from robin.model import LlavaMPTForCausalLM, LlavaMistralForCausalLM, LlavaGPTNeoXForCausalLM, LlavaLlamaForCausalLM 
+from robin.model import LlavaMistralForCausalLM, LlavaGPTNeoXForCausalLM, LlavaLlamaForCausalLM#, LlavaMPTForCausalLM [TODO] mpt is commented out at robin.model.__init__
 from robin.mm_utils import tokenizer_image_token, expand2square
 
 from PIL import Image
@@ -816,11 +816,11 @@ def train():
                 use_flash_attention_2 = USE_FLASH_ATTN_2,
                 **bnb_model_from_pretrained_args
             )
-        elif 'neox' in model_args.model_name_or_path:
+        elif 'pythia' in model_args.model_name_or_path:
             model = LlavaGPTNeoXForCausalLM.from_pretrained(
                 model_args.model_name_or_path,
                 cache_dir=training_args.cache_dir,
-                use_flash_attention_2 = True,
+                use_flash_attention_2 = False, # The current architecture does not support Flash Attention 2.0
                 **bnb_model_from_pretrained_args
             )
         else:

--- a/robin/train/train.py
+++ b/robin/train/train.py
@@ -21,6 +21,7 @@ import json
 import logging
 import pathlib
 from typing import Dict, Optional, Sequence, List
+import glob
 
 import torch
 
@@ -985,9 +986,7 @@ def train():
     print(model)
     for name, param in model.named_parameters():
         print(name, param.requires_grad)
-    
-    
-    import glob
+
     checkpoints = sorted(glob.glob(f"{training_args.output_dir}/checkpoint-*"))
 
     if training_args.only_save_model:

--- a/robin/train/train.py
+++ b/robin/train/train.py
@@ -824,7 +824,6 @@ def train():
                 **bnb_model_from_pretrained_args
             )
         else:
-            # print(model_args)
             model = LlavaLlamaForCausalLM.from_pretrained(
                 model_args.model_name_or_path,
                 cache_dir=training_args.cache_dir,

--- a/robin/train/train.py
+++ b/robin/train/train.py
@@ -31,7 +31,7 @@ from torch.utils.data import Dataset
 from robin.train.llava_trainer import LLaVATrainer
 
 from robin import conversation as conversation_lib
-from robin.model import *
+from robin.model import LlavaMPTForCausalLM, LlavaMistralForCausalLM, LlavaGPTNeoXForCausalLM, LlavaLlamaForCausalLM 
 from robin.mm_utils import tokenizer_image_token, expand2square
 
 from PIL import Image

--- a/robin/train/train_mem.py
+++ b/robin/train/train_mem.py
@@ -1,23 +1,27 @@
 # Adopted from https://github.com/lm-sys/FastChat. Below is the original copyright:
 # Adopted from tatsu-lab@stanford_alpaca. Below is the original copyright:
 # Make it more memory efficient by monkey patching the LLaMA model with FlashAttn.
-import sys
-sys.path.append('.')  # TODO: is this really necessary?
 import os
-
-username = os.environ.get('USER')
-hostname = os.environ.get('HOSTNAME')
-jobid = os.environ.get('SLURM_JOB_ID')
-
-os.environ['WANDB_DIR'] = f'/lustre/orion/csc538/scratch/{username}/wandb_cache'
-os.environ['MIOPEN_USER_DB_PATH'] = f'/lustre/orion/csc538/scratch/{username}/miopen/{jobid}/{hostname}'
-os.environ['TRANSFORMERS_CACHE'] = '/lustre/orion/csc538/proj-shared/downloaded_models/hf_cache'
-os.environ['WANDB_MODE'] = 'offline'
-os.environ['TRANSFORMERS_OFFLINE'] = '1'
-os.environ['HF_DATASETS_OFFLINE'] = '1'
-os.environ['MIOPEN_CUSTOM_CACHE_DIR'] = os.environ['MIOPEN_USER_DB_PATH']
-
+import sys
+sys.path.append('.')
 from robin.train.train import train
 
 if __name__ == "__main__":
+    if os.path.exists("/lustre/orion/csc538"): # if running on frontier
+        username = os.environ.get('USER')
+        hostname = os.environ.get('HOSTNAME')
+        jobid = os.environ.get('SLURM_JOB_ID')
+
+        miopen_use_db_path = f'/lustre/orion/csc538/scratch/{username}/miopen/{jobid}/{hostname}'
+        if not os.path.exists(miopen_use_db_path):
+            os.makedirs(miopen_use_db_path) 
+        os.environ['MIOPEN_USER_DB_PATH'] = miopen_use_db_path
+        os.environ['MIOPEN_CUSTOM_CACHE_DIR'] = os.environ['MIOPEN_USER_DB_PATH']
+
+        os.environ['WANDB_DIR'] = f'/lustre/orion/csc538/scratch/{username}/wandb_cache'
+        os.environ['TRANSFORMERS_CACHE'] = '/lustre/orion/csc538/proj-shared/downloaded_models/hf_cache'
+        os.environ['WANDB_MODE'] = 'offline'
+        os.environ['TRANSFORMERS_OFFLINE'] = '1'
+        os.environ['HF_DATASETS_OFFLINE'] = '1'
+
     train()

--- a/scripts/pythia-410m-clip/pretrain.sh
+++ b/scripts/pythia-410m-clip/pretrain.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# This scripts is used for testing the feasibility of 
+# Training pythia-410m clip on local 4 gpus machine.
+
+# Gradient_checkpointing is set to False because I meet NotImplementedError 
+# When calling model.enable_input_require_grads() of pythia model instance
+
+# FlashAttenion2 is disable as well at robin/train/train.py #824
+
+MODEL='EleutherAI/pythia-410m'
+VISION=openai/clip-vit-large-patch14-336
+TRAIN_PATH=/home/lfsm/code/Robin/
+CHECKPOINT_PATH=/home/lfsm/code/Robin/robin/checkpoints
+DATA_PATH=/home/lfsm/code/Robin/playground-original/llava_pretrain
+
+deepspeed \
+    $TRAIN_PATH/robin/train/train_mem.py \
+    --deepspeed ./scripts/zero2.json \
+    --model_name_or_path $MODEL \
+    --version plain \
+    --data_path $DATA_PATH/blip_laion_cc_sbu_558k.json \
+    --image_folder $DATA_PATH/images \
+    --vision_tower $VISION \
+    --finetune_ve False \
+    --mm_projector_type mlp2x_gelu \
+    --tune_mm_mlp_adapter True \
+    --mm_vision_select_layer -2 \
+    --mm_use_im_start_end False \
+    --mm_use_im_patch_token False \
+    --fp16 True \
+    --output_dir $CHECKPOINT_PATH/pretrain \
+    --num_train_epochs 1 \
+    --per_device_train_batch_size 32 \
+    --per_device_eval_batch_size 4 \
+    --gradient_accumulation_steps 1 \
+    --evaluation_strategy "no" \
+    --save_strategy "steps" \
+    --save_steps 100 \
+    --save_total_limit 1 \
+    --learning_rate 1e-3 \
+    --weight_decay 0. \
+    --warmup_ratio 0.03 \
+    --lr_scheduler_type "cosine" \
+    --logging_steps 1 \
+    --tf32 False \
+    --model_max_length 2048 \
+    --gradient_checkpointing False \
+    --dataloader_num_workers 4 \
+    --lazy_preprocess True \
+    # --report_to wandb

--- a/scripts/v1_5/pretrain_multinodes.sh
+++ b/scripts/v1_5/pretrain_multinodes.sh
@@ -29,8 +29,7 @@ bash /lustre/orion/csc538/scratch/$(whoami)/frontier_write_hostfile.sh
 
 cd $TRAIN_PATH
 
-#deepspeed --hostfile /lustre/orion/csc538/scratch/$(whoami)/hostfiles/$SLURM_JOBID-hosts \
-deepspeed \
+deepspeed --hostfile /lustre/orion/csc538/scratch/$(whoami)/hostfiles/$SLURM_JOBID-hosts \
     $TRAIN_PATH/robin/train/train_mem.py \
     --deepspeed ./scripts/zero2.json \
     --model_name_or_path $MODEL \

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,70 @@
+import unittest
+import torch
+from transformers import LlamaConfig, GPTNeoXConfig
+from robin.model import LlavaLlamaForCausalLM, LlavaGPTNeoXForCausalLM
+
+@unittest.skip('Need 300 second to Run')
+class TestLlavaLlama(unittest.TestCase):
+    def setUp(self):
+        config = LlamaConfig.from_pretrained("meta-llama/Llama-2-7b-hf")
+        config.vision_tower = "openai/clip-vit-large-patch14-336"
+        config.mm_vision_tower = config.vision_tower
+        config.mm_projector_type = "mlp2x_gelu"
+        config.mm_vision_select_layer = -2
+        config.mm_vision_select_feature = "patch"
+        config.mm_hidden_size = 1024
+        config.pretrain_mm_mlp_adapter = None
+
+        self.model = LlavaLlamaForCausalLM(config)
+        self.model.get_model().initialize_vision_modules(config)
+        self.vision_tower = self.model.get_vision_tower()
+        
+        assert self.model is not None
+        assert self.vision_tower is not None
+
+    def test_llava_llama_forward(self):
+        input_ids = torch.tensor([[101, 2054, 2003, 1037, 2518, 1012, 102]]) 
+        use_cache = True 
+        images = torch.randn(1, 3, 336, 336)
+
+        output = self.model(
+            input_ids=input_ids,
+            use_cache=use_cache,
+            images=images,
+        )
+
+        assert output[0].shape == torch.Size([1, 7, 32000])
+        
+
+class TestLlavaNeox(unittest.TestCase):
+    def setUp(self):
+        config = GPTNeoXConfig.from_pretrained("EleutherAI/pythia-410m")
+        config.vision_tower = "openai/clip-vit-large-patch14-336"
+        config.mm_vision_tower = config.vision_tower
+        config.mm_projector_type = "mlp2x_gelu"
+        config.mm_vision_select_layer = -2
+        config.mm_vision_select_feature = "patch"
+        config.mm_hidden_size = 1024
+        config.pretrain_mm_mlp_adapter = None
+
+        self.model = LlavaGPTNeoXForCausalLM(config)
+        self.model.get_model().initialize_vision_modules(config)
+        self.vision_tower = self.model.get_vision_tower()
+        
+        assert self.model is not None
+        assert self.vision_tower is not None
+
+    def test_llava_neox_forward(self):
+        input_ids = torch.tensor([[101, 2054, 2003, 1037, 2518, 1012, 102]]) 
+        use_cache = True  # Example boolean value for use_cache
+        images = torch.randn(1, 3, 336, 336)  # Example images tensor
+        output = self.model(
+            input_ids=input_ids,
+            use_cache=use_cache,
+            images=images,
+        )
+        assert output[0].shape == torch.Size([1, 7, 50304])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,7 +3,7 @@ import torch
 from transformers import LlamaConfig, GPTNeoXConfig
 from robin.model import LlavaLlamaForCausalLM, LlavaGPTNeoXForCausalLM
 
-@unittest.skip('Need 300 second to Run, init llama 7b takes time')
+@unittest.skip('Need 300 second to Run LlavaLlama')
 class TestLlavaLlama(unittest.TestCase):
     def setUp(self):
         config = LlamaConfig.from_pretrained("meta-llama/Llama-2-7b-hf")
@@ -65,6 +65,9 @@ class TestLlavaNeox(unittest.TestCase):
         )
         
         assert output[0].shape == torch.Size([1, 7, 50304])
+
+    def test_llava_neox_from_pretrained(self):
+        self.pretrain_model = LlavaGPTNeoXForCausalLM.from_pretrained("EleutherAI/pythia-410m")
 
 
 if __name__ == '__main__':

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,7 @@
 import unittest
 import torch
 from transformers import LlamaConfig, GPTNeoXConfig
-from robin.model import LlavaLlamaForCausalLM, LlavaGPTNeoXForCausalLM
+from robin.model import LlavaLlamaForCausalLM, LlavaGPTNeoXForCausalLM, LlavaMistralForCausalLM
 
 @unittest.skip('Need 300 second to Run LlavaLlama')
 class TestLlavaLlama(unittest.TestCase):
@@ -68,6 +68,12 @@ class TestLlavaNeox(unittest.TestCase):
 
     def test_llava_neox_from_pretrained(self):
         self.pretrain_model = LlavaGPTNeoXForCausalLM.from_pretrained("EleutherAI/pythia-410m")
+
+
+class TestLlavaMistral(unittest.TestCase):
+    def test_llava_mistral_from_pretrained(self):
+        pretrain_model = LlavaMistralForCausalLM.from_pretrained("mistralai/Mistral-7B-Instruct-v0.1")
+        assert pretrain_model is not None
 
 
 if __name__ == '__main__':

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,7 +3,7 @@ import torch
 from transformers import LlamaConfig, GPTNeoXConfig
 from robin.model import LlavaLlamaForCausalLM, LlavaGPTNeoXForCausalLM
 
-@unittest.skip('Need 300 second to Run')
+@unittest.skip('Need 300 second to Run, init llama 7b takes time')
 class TestLlavaLlama(unittest.TestCase):
     def setUp(self):
         config = LlamaConfig.from_pretrained("meta-llama/Llama-2-7b-hf")
@@ -56,13 +56,14 @@ class TestLlavaNeox(unittest.TestCase):
 
     def test_llava_neox_forward(self):
         input_ids = torch.tensor([[101, 2054, 2003, 1037, 2518, 1012, 102]]) 
-        use_cache = True  # Example boolean value for use_cache
-        images = torch.randn(1, 3, 336, 336)  # Example images tensor
+        use_cache = True 
+        images = torch.randn(1, 3, 336, 336)
         output = self.model(
             input_ids=input_ids,
             use_cache=use_cache,
             images=images,
         )
+        
         assert output[0].shape == torch.Size([1, 7, 50304])
 
 


### PR DESCRIPTION
This PR tests and supports pythia 410M model, the whole series model shall work as well, several changes as followed:
1. Refactor the class LlavaGPTNeoXForCausalLM to fix the from_pretrained() weight mismatch error
3. Add unit test for both LlavaLlama and LlavaNeox at tests/test_models.py, we can use this as template for further model supports
4. Add scripts for running pythia410M+clip
5. Reformat train_mem.py and train.py alittle, :)

FYI: 
Both flash attention and gradient checkpoint are disable because I meet error reported from hf side. 
we can try to debuy it but pythia models is not that large and frontier can afford it.

This PR is well tested and is able to train the pythia410M+clip, here is the log
[log.txt](https://github.com/AGI-Collective/Robin/files/13852722/log.txt)
