### PR TITLE
Add eval scripts for Clevr and Qlevr benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Build dir
+build
+
 # (Symlink to a) working dir to store official Llava datasets
 playground
 

--- a/robin/eval/eval_vqa_clevr.py
+++ b/robin/eval/eval_vqa_clevr.py
@@ -1,0 +1,76 @@
+import os
+import argparse
+import json
+import re
+import pandas as pd
+
+from tqdm import tqdm
+
+NUMBERS = ['zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten']
+
+def generate_score(args):
+    question_filepath = args.question_file
+    answer_filepath = args.answers_file
+    with open(question_filepath, 'r') as f:
+        question_data = json.load(f)
+    question_df = pd.DataFrame(question_data["questions"])
+
+    predicted_answers = [json.loads(line) for line in open(answer_filepath, 'r')]
+
+    num_correct = 0
+    num_total = len(predicted_answers)
+    correct_list = []
+    wrong_list = []
+
+    for pred_ans in tqdm(predicted_answers):
+        question_idx = pred_ans["question_id"]
+        pred_val = pred_ans["text"].lower()
+        ground_truth_val = question_df[question_df["question_index"] == question_idx]["answer"].values[0].lower()
+
+        # Convert to text if ground truth is an integer
+        try:
+            num = int(ground_truth_val)
+            ground_truth_val = NUMBERS[num]
+        except Exception as e:
+            pass
+
+        yesno_match =  re.search(r'^(yes|no)', pred_val)
+        next_word_matches = re.finditer(r'(?:is made of|is a|has a|there are|made of|is) (\w+)', pred_val)
+        
+        if yesno_match:
+            pred_word = yesno_match.group(1)
+            if ground_truth_val == pred_word:
+                num_correct += 1
+                correct_list.append([ground_truth_val, pred_val])
+            else:
+                wrong_list.append([ground_truth_val, pred_val])
+        
+        # Find all words that come right after 'is a', 'there are', 'is', 'made of'
+        elif next_word_matches:
+            found = False
+            for next_word_match in next_word_matches:
+                pred_word = next_word_match.group(1)
+
+                if ground_truth_val == pred_word:
+                    num_correct += 1
+                    found = True
+                    correct_list.append([ground_truth_val, pred_val])
+                    break
+
+            if not found:
+                wrong_list.append([ground_truth_val, pred_val])    
+
+        else:
+            wrong_list.append([ground_truth_val, pred_val])
+
+    acc = round(num_correct / num_total, 5)
+    print(f"Accuracy: {acc} ; {num_correct} / {num_total} correct.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--question-file", type=str, default="CLEVR_v1.0/questions/CLEVR_test_questions.json")
+    parser.add_argument("--answers-file", type=str, default="answers.jsonl")
+    args = parser.parse_args()
+
+    generate_score(args)

--- a/robin/eval/eval_vqa_qlevr.py
+++ b/robin/eval/eval_vqa_qlevr.py
@@ -1,0 +1,54 @@
+import os
+import argparse
+import json
+import re
+import pandas as pd
+
+from tqdm import tqdm
+
+def generate_score(args):
+    question_filepath = args.question_file
+    answer_filepath = args.answers_file
+    
+    with open(question_filepath, 'r') as f:
+        question_data = json.load(f)
+
+    question_df = pd.DataFrame(question_data["questions"])
+
+    predicted_answers = [json.loads(line) for line in open(answer_filepath, 'r')]
+
+    num_correct = 0
+    num_total = len(predicted_answers)
+    correct_list = []
+    wrong_list = []
+
+    for pred_ans in tqdm(predicted_answers):
+        question_idx = pred_ans["question_id"]
+        pred_val = pred_ans["text"].lower()
+        ground_truth_val = question_df[question_df["question_index"] == question_idx]["answer"].values[0]
+
+        yesno_match =  re.search(r'^(yes|no)', pred_val)
+        
+        if yesno_match:
+            pred_word = yesno_match.group(1)
+            pred_word = True if pred_word == 'yes' else False
+            
+            if ground_truth_val == pred_word:
+                num_correct += 1
+                correct_list.append([ground_truth_val, pred_val])
+            else:
+                wrong_list.append([ground_truth_val, pred_val])
+        else:
+            wrong_list.append([ground_truth_val, pred_val])
+
+    acc = round(num_correct / num_total, 5)
+    print(f"Accuracy: {acc} ; {num_correct} / {num_total} correct.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--question-file", type=str, default="questions_test.json")
+    parser.add_argument("--answers-file", type=str, default="answers.jsonl")
+    args = parser.parse_args()
+
+    generate_score(args)

--- a/robin/eval/model_vqa_clevr.py
+++ b/robin/eval/model_vqa_clevr.py
@@ -1,8 +1,10 @@
 import os
 import argparse
 import json
-from tqdm import tqdm
 import shortuuid
+import random
+
+from tqdm import tqdm
 
 from robin.serve.robin_inference import Robin
 
@@ -10,24 +12,36 @@ from robin.serve.robin_inference import Robin
 # https://dl.fbaipublicfiles.com/clevr/CLEVR_v1.0.zip
 # e.g. CLEVR_v1.0/questions/CLEVR_test_questions.json , which correspond to images in CLEVR_v1.0/images/test
 def eval_model(args):
+    # To ensure deterministic sampling
+    random.seed(args.seed)
+
     questions_file_path = os.path.expanduser(args.question_file)
     img_folder = os.path.expanduser(args.image_folder)
     answers_file = os.path.expanduser(args.answers_file)
     question_data = [ json.loads(line) for line in open(os.path.expanduser(questions_file_path), "r")]
     questions = question_data[0]["questions"]
+    num_samples = args.sample
+    question_indices = [ i for i in range(len(questions)) ]
+
+    if num_samples > 0:
+        print(f"Randomly sampling {num_samples}/{len(questions)} questions using seed {args.seed}")
+        random.shuffle(question_indices)
+        question_indices = question_indices[:num_samples]
+    else:
+        print(f"Doing inference on full set of {len(questions)} questions")
 
     ans_file = open(answers_file, "w")
 
     robin = Robin(args.model_path,
                 model_base=args.model_base,
-                device="cuda",
-                conv_mode="llava_v1",
-                temperature=0.2,
+                device=args.device,
+                conv_mode=args.conv_mode,
+                temperature=args.temperature,
                 max_new_tokens=128
             )
 
-    for q in tqdm(questions):
-
+    for idx in tqdm(question_indices):
+        q = questions[idx]
         question_idx = q["question_index"]
         image_filename = q["image_filename"]
         image_path = os.path.join(img_folder, image_filename)
@@ -57,9 +71,13 @@ if __name__ == "__main__":
     parser.add_argument("--conv-mode", type=str, default="llava_v1")
     parser.add_argument("--num-chunks", type=int, default=1)
     parser.add_argument("--chunk-idx", type=int, default=0)
-    parser.add_argument("--temperature", type=float, default=0.2)
+    parser.add_argument("--temperature", type=float, default=0)
     parser.add_argument("--top_p", type=float, default=None)
     parser.add_argument("--num_beams", type=int, default=1)
+    parser.add_argument("--sample", type=int, default=0, help="Number of questions to sample. If 0 (default), full question set is used.")
+    parser.add_argument("--device", type=str, default="cuda", help="Device to use. Default is 'cuda'. For specific GPU, input 'cuda:<device_id>'.")
+    parser.add_argument("--seed", type=int, default=1234, help="Random seed, default is 1234.")
+
     args = parser.parse_args()
 
     eval_model(args)

--- a/robin/eval/model_vqa_qlevr.py
+++ b/robin/eval/model_vqa_qlevr.py
@@ -1,8 +1,10 @@
 import os
 import argparse
 import json
-from tqdm import tqdm
 import shortuuid
+import random
+
+from tqdm import tqdm
 
 from robin.serve.robin_inference import Robin
 
@@ -10,24 +12,36 @@ from robin.serve.robin_inference import Robin
 # https://drive.google.com/drive/folders/1s0n4CQXr1IDmBVUymYH51iC1MF54jyhN
 # e.g. questions_test.json , which correspond to images in 2d_scene/test/full_images/2d_full_test_<image-id>.png or 3d_scene/test/images/3d_test_<image-id>.png
 def eval_model(args):
+    # To ensure deterministic sampling
+    random.seed(args.seed)
+
     questions_file_path = os.path.expanduser(args.question_file)
     img_folder = os.path.expanduser(args.image_folder)
     answers_file = os.path.expanduser(args.answers_file)
     question_data = [ json.loads(line) for line in open(os.path.expanduser(questions_file_path), "r")]
     questions = question_data[0]["questions"]
+    num_samples = args.sample
+    question_indices = [ i for i in range(len(questions)) ]
 
+    if num_samples > 0:
+        print(f"Randomly sampling {num_samples}/{len(questions)} questions using seed {args.seed}")
+        random.shuffle(question_indices)
+        question_indices = question_indices[:num_samples]
+    else:
+        print(f"Doing inference on full set of {len(questions)} questions")
+        
     ans_file = open(answers_file, "w")
 
     robin = Robin(args.model_path,
                 model_base=args.model_base,
-                device="cuda",
-                conv_mode="llava_v1",
-                temperature=0.2,
+                device=args.device,
+                conv_mode=args.conv_mode,
+                temperature=args.temperature,
                 max_new_tokens=128
             )
 
-    for q in tqdm(questions):
-
+    for idx in tqdm(question_indices):
+        q = questions[idx]
         question_idx = q["question_index"]
         image_filename = f"{args.image_prefix}" + "{:06d}".format(int(q["image_index"])) + ".png"
         image_path = os.path.join(img_folder, image_filename)
@@ -58,9 +72,13 @@ if __name__ == "__main__":
     parser.add_argument("--conv-mode", type=str, default="llava_v1")
     parser.add_argument("--num-chunks", type=int, default=1)
     parser.add_argument("--chunk-idx", type=int, default=0)
-    parser.add_argument("--temperature", type=float, default=0.2)
+    parser.add_argument("--temperature", type=float, default=0)
     parser.add_argument("--top_p", type=float, default=None)
     parser.add_argument("--num_beams", type=int, default=1)
+    parser.add_argument("--sample", type=int, default=0, help="Number of questions to sample. If 0 (default), full question set is used.")
+    parser.add_argument("--device", type=str, default="cuda", help="Device to use. Default is 'cuda'. For specific GPU, input 'cuda:<device_id>'.")
+    parser.add_argument("--seed", type=int, default=1234, help="Random seed, default is 1234.")
+
     args = parser.parse_args()
 
     eval_model(args)


### PR DESCRIPTION
1. Added eval scripts for calculating prediction accuracy for Clevr and Qlevr benchmarks
  - `robin/eval/eval_vqa_clevr.py`
  - `robin/eval/eval_vqa_qlevr.py`

2. Modified the inference scripts for Clevr and Qlevr to support question sampling during eval with a given seed
  - `robin/eval/model_vqa_clevr.py`
  - `robin/eval/model_vqa_qlevr.py`